### PR TITLE
stringify twin patch property value

### DIFF
--- a/lib/hub-reporter.js
+++ b/lib/hub-reporter.js
@@ -6,7 +6,7 @@ module.exports = class HubReporter {
     reportFirmwareUpdate(firmwareUpdateValue) {
         const self = this;
         const patch = {
-            firmwareUpdate: firmwareUpdateValue
+            firmwareUpdate: JSON.stringify(firmwareUpdateValue)
         };
 
         return new Promise(function (fulfill, reject) {


### PR DESCRIPTION
👋 

I'm probably doing something wrong here, so feel free to close this if so.
When the twin update is picked up by IoT Hub, it comes out the other end reading like this:

```
{
  ...
  firmwareUpdate: [Object object]
  ...
}
```

I caught this twin update via a custom route from IoTHub, connected to an Event Hub endpoint. When the Event Hub triggers an Azure function, most of the message comes through ok except for that one nested object property.

Any shortcuts you can think of to solve this instead of stringifying it on the way in?